### PR TITLE
Fixed problem with ubuntu gcc linker 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 all: *.cpp
-	g++ -O3 -Wall `pkg-config --cflags --libs opencv` -lrt -o hesaff pyramid.cpp affine.cpp siftdesc.cpp helpers.cpp hesaff.cpp
+	g++ -O3 -Wall -o hesaff pyramid.cpp affine.cpp siftdesc.cpp helpers.cpp hesaff.cpp `pkg-config opencv --cflags --libs` -lrt 


### PR DESCRIPTION
When compiled on the Ubuntu platform, it failed with undefined reference linker problem. Solved putting cpp files before libraries in gcc command parameters.
