### PR TITLE
Use new opencv includes

### DIFF
--- a/affine.h
+++ b/affine.h
@@ -4,14 +4,14 @@
  *
  * This file is part of the HessianAffine detector and is made available under
  * the terms of the BSD license (see the COPYING file).
- * 
+ *
  */
 
 #ifndef __AFFINE_H__
 #define __AFFINE_H__
 
 #include <vector>
-#include <cv.h>
+#include <opencv2/opencv.hpp>
 #include "helpers.h"
 
 struct AffineShapeParams
@@ -22,7 +22,7 @@ struct AffineShapeParams
    // convergence threshold, i.e. maximum deviation from isotropic shape at convergence
    float convergenceThreshold;
 
-   // widht and height of the SMM mask 
+   // widht and height of the SMM mask
    int smmWindowSize;
 
    // width and height of the patch
@@ -52,34 +52,34 @@ struct AffineShapeCallback
       float x, float y,     // subpixel, image coordinates
       float s,              // scale
       float pixelDistance,  // distance between pixels in provided blured image
-      float a11, float a12, // affine shape matrix 
-      float a21, float a22, 
+      float a11, float a12, // affine shape matrix
+      float a21, float a22,
       int type, float response, int iters) = 0;
 };
 
 struct AffineShape
 {
-public:   
-   AffineShape(const AffineShapeParams &par) : 
+public:
+   AffineShape(const AffineShapeParams &par) :
       patch(par.patchSize, par.patchSize, CV_32FC1),
-      mask(par.smmWindowSize, par.smmWindowSize, CV_32FC1), 
-      img(par.smmWindowSize, par.smmWindowSize, CV_32FC1), 
-      fx(par.smmWindowSize, par.smmWindowSize, CV_32FC1), 
+      mask(par.smmWindowSize, par.smmWindowSize, CV_32FC1),
+      img(par.smmWindowSize, par.smmWindowSize, CV_32FC1),
+      fx(par.smmWindowSize, par.smmWindowSize, CV_32FC1),
       fy(par.smmWindowSize, par.smmWindowSize, CV_32FC1)
-      {                     
+      {
          this->par = par;
          computeGaussMask(mask);
          affineShapeCallback = 0;
          fx = cv::Scalar(0);
          fy = cv::Scalar(0);
       }
-   
+
    ~AffineShape()
       {
       }
-   
-   // computes affine shape 
-   bool findAffineShape(const cv::Mat &blur, float x, float y, float s, float pixelDistance, int type, float response);   
+
+   // computes affine shape
+   bool findAffineShape(const cv::Mat &blur, float x, float y, float s, float pixelDistance, int type, float response);
 
    // fills patch with affine normalized neighbourhood around point in the img, enlarged mrSize times
    bool normalizeAffine(const cv::Mat &img, float x, float y, float s, float a11, float a12, float a21, float a22);

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -4,12 +4,12 @@
  *
  * This file is part of the HessianAffine detector and is made available under
  * the terms of the BSD license (see the COPYING file).
- * 
+ *
  */
 
 #include <cmath>
 #include <iostream>
-#include <cv.h>
+#include <opencv2/opencv.hpp>
 
 using namespace cv;
 using namespace std;
@@ -21,14 +21,14 @@ using namespace std;
 #include <stdio.h>
 
 double getTime()
-{     
-#ifdef _POSIX_CPUTIME                                                                                                                                         
+{
+#ifdef _POSIX_CPUTIME
    struct timespec ts;
    if (!clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts))
    {
       return (double)(ts.tv_sec) + (double)(ts.tv_nsec)/1.0e9;
    } else
-#endif                                                                                                                                                 
+#endif
    {
       // fall back to standard unix time
       struct timeval tv;
@@ -48,34 +48,34 @@ void solveLinear3x3(float *A, float *b)
    // find pivot of first column
    int i = 0;
    float *pr = A;
-   float vp = abs(A[0]); 
-   float tmp = abs(A[3]);   
-   if (tmp > vp) 
-   { 
+   float vp = abs(A[0]);
+   float tmp = abs(A[3]);
+   if (tmp > vp)
+   {
       // pivot is in 1st row
-      pr = A+3; 
-      i = 1; 
-      vp = tmp; 
+      pr = A+3;
+      i = 1;
+      vp = tmp;
    }
-   if (abs(A[6]) > vp) 
-   { 
+   if (abs(A[6]) > vp)
+   {
       // pivot is in 2nd row
       pr = A+6;
       i = 2;
    }
-   
+
    // swap pivot row with first row
    if (pr != A) { swap(pr, A); swap(pr+1, A+1); swap(pr+2, A+2); swap(b+i, b); }
-   
+
    // fixup elements 3,4,5,b[1]
    vp = A[3] / A[0]; A[4] -= vp*A[1]; A[5] -= vp*A[2]; b[1] -= vp*b[0];
-   
+
    // fixup elements 6,7,8,b[2]]
    vp = A[6] / A[0]; A[7] -= vp*A[1]; A[8] -= vp*A[2]; b[2] -= vp*b[0];
-   
+
    // find pivot in second column
    if (abs(A[4]) < abs(A[7])) { swap(A+7, A+4); swap(A+8, A+5); swap(b+2, b+1); }
-   
+
    // fixup elements 7,8,b[2]
    vp = A[7] / A[4];
    A[8] -= vp*A[5];
@@ -89,11 +89,11 @@ void solveLinear3x3(float *A, float *b)
 
 void rectifyAffineTransformationUpIsUp(float &a11, float &a12, float &a21, float &a22)
 {
-   double a = a11, b = a12, c = a21, d = a22;   
+   double a = a11, b = a12, c = a21, d = a22;
    double det = sqrt(abs(a*d-b*c));
    double b2a2 = sqrt(b*b + a*a);
    a11 = b2a2/det;             a12 = 0;
-   a21 = (d*b+c*a)/(b2a2*det); a22 = det/b2a2;   
+   a21 = (d*b+c*a)/(b2a2*det); a22 = det/b2a2;
 }
 
 void rectifyAffineTransformationUpIsUp(float *U)
@@ -107,8 +107,8 @@ void computeGaussMask(Mat &mask)
    int halfSize = size >> 1;
    // fit 3*sigma into half_size
    float scale = float(halfSize)/3.0f;
-   
-   float scale2 = -2.0f * scale * scale;   
+
+   float scale2 = -2.0f * scale * scale;
    float *tmp = new float[halfSize+1];
    for (int i = 0; i<= halfSize; i++)
       tmp[i] = exp((float(i*i)/scale2));
@@ -116,13 +116,13 @@ void computeGaussMask(Mat &mask)
    int endSize = int(ceil(scale*5.0f)-halfSize);
    for (int i = 1; i< endSize; i++)
       tmp[halfSize-i] += exp((float((i+halfSize)*(i+halfSize))/scale2));
-      
+
    for (int i=0; i<=halfSize; i++)
       for (int j=0; j<=halfSize; j++)
       {
-         mask.at<float>   ( i+halfSize,-j+halfSize) = 
-            mask.at<float>(-i+halfSize, j+halfSize) = 
-            mask.at<float>( i+halfSize, j+halfSize) = 
+         mask.at<float>   ( i+halfSize,-j+halfSize) =
+            mask.at<float>(-i+halfSize, j+halfSize) =
+            mask.at<float>( i+halfSize, j+halfSize) =
             mask.at<float>(-i+halfSize,-j+halfSize) = tmp[i]*tmp[j];
       }
    delete [] tmp;
@@ -144,7 +144,7 @@ void computeCircularGaussMask(Mat &mask)
          disq = float((i-halfSize)*(i-halfSize)+(j-halfSize)*(j-halfSize));
          *mp++ = (disq < r2) ? exp(- disq / sigma2) : 0;
       }
-}  
+}
 
 void invSqrt(float &a, float &b, float &c, float &l1, float &l2)
 {
@@ -160,10 +160,10 @@ void invSqrt(float &a, float &b, float &c, float &l1, float &l2)
       t = 0;
    }
    double x,z,d;
-      
+
    x = 1.0/sqrt(r*r*a-2*r*t*b+t*t*c);
    z = 1.0/sqrt(t*t*a+2*r*t*b+r*r*c);
-      
+
    d = sqrt(x*z);
    x /= d; z /= d;
    // let l1 be the greater eigenvalue
@@ -173,15 +173,15 @@ void invSqrt(float &a, float &b, float &c, float &l1, float &l2)
    b = float(-r*t*x+t*r*z);
    c = float( t*t*x+r*r*z);
 }
-   
+
 bool getEigenvalues(float a, float b, float c, float d, float &l1, float &l2)
 {
    float trace = a+d;
-   float delta1 = (trace*trace-4*(a*d-b*c));      
+   float delta1 = (trace*trace-4*(a*d-b*c));
    if (delta1 < 0)
       return false;
    float delta = sqrt(delta1);
-      
+
    l1 = (trace+delta)/2.0f;
    l2 = (trace-delta)/2.0f;
    return true;
@@ -189,7 +189,7 @@ bool getEigenvalues(float a, float b, float c, float d, float &l1, float &l2)
 
 // check if we are not too close to boundary of the image/
 bool interpolateCheckBorders(const Mat &im, float ofsx, float ofsy, float a11, float a12, float a21, float a22, const Mat &res)
-{         
+{
    const int width = im.cols-2;
    const int height = im.rows-2;
    const int halfWidth  = res.cols >> 1;
@@ -207,7 +207,7 @@ bool interpolateCheckBorders(const Mat &im, float ofsx, float ofsy, float a11, f
 }
 
 bool interpolate(const Mat &im, float ofsx, float ofsy, float a11, float a12, float a21, float a22, Mat &res)
-{         
+{
    bool ret = false;
    // input size (-1 for the safe bilinear interpolation)
    const int width = im.cols-1;
@@ -231,12 +231,12 @@ bool interpolate(const Mat &im, float ofsx, float ofsy, float a11, float a12, fl
             // compute weights
             wx -= x; wy -= y;
             // bilinear interpolation
-            *out++ = 
+            *out++ =
                (1.0f - wy) * ((1.0f - wx) * im.at<float>(y,x)   + wx * im.at<float>(y,x+1)) +
                (       wy) * ((1.0f - wx) * im.at<float>(y+1,x) + wx * im.at<float>(y+1,x+1));
          } else {
             *out++ = 0;
-            ret =  true; // touching boundary of the input            
+            ret =  true; // touching boundary of the input
          }
       }
    }
@@ -244,21 +244,21 @@ bool interpolate(const Mat &im, float ofsx, float ofsy, float a11, float a12, fl
 }
 
 void photometricallyNormalize(Mat &image, const Mat &binaryMask, float &sum, float &var)
-{   
+{
    const int width = image.cols;
    const int height = image.rows;
    sum=0;
-   float gsum=0; 
+   float gsum=0;
 
    for (int j=0; j < height; j++)
       for (int i=0; i < width; i++)
          if (binaryMask.at<float>(j,i)>0)
          {
-            sum += image.at<float>(j,i); 
+            sum += image.at<float>(j,i);
             gsum ++;
          }
    sum = sum / gsum;
-         
+
    var=0;
    for (int j=0; j < height; j++)
       for (int i=0; i < width; i++)
@@ -270,10 +270,10 @@ void photometricallyNormalize(Mat &image, const Mat &binaryMask, float &sum, flo
       // if variance is too low, don't do anything
       return;
 
-   float fac = 50.0f/var;   
+   float fac = 50.0f/var;
    for (int j=0; j < height; j++)
       for (int i=0; i < width; i++)
-      { 
+      {
          image.at<float>(j,i) = 128 + fac * (image.at<float>(j,i) - sum);
          if (image.at<float>(j,i) > 255) image.at<float>(j,i)=255;
          if (image.at<float>(j,i) < 0)   image.at<float>(j,i)=0;
@@ -283,14 +283,14 @@ void photometricallyNormalize(Mat &image, const Mat &binaryMask, float &sum, flo
 Mat gaussianBlur(const Mat input, float sigma)
 {
    Mat ret(input.rows, input.cols, input.type());
-   int size = (int)(2.0 * 3.0 * sigma + 1.0); if (size % 2 == 0) size++;      
+   int size = (int)(2.0 * 3.0 * sigma + 1.0); if (size % 2 == 0) size++;
    GaussianBlur(input, ret, Size(size, size), sigma, sigma, BORDER_REPLICATE);
    return ret;
 }
 
 void gaussianBlurInplace(Mat &inplace, float sigma)
 {
-   int size = (int)(2.0 * 3.0 * sigma + 1.0); if (size % 2 == 0) size++;      
+   int size = (int)(2.0 * 3.0 * sigma + 1.0); if (size % 2 == 0) size++;
    GaussianBlur(inplace, inplace, Size(size, size), sigma, sigma, BORDER_REPLICATE);
 }
 
@@ -298,11 +298,11 @@ Mat doubleImage(const Mat &input)
 {
    Mat n(input.rows*2, input.cols*2, input.type());
    const float *in = input.ptr<float>(0);
-   
+
    for (int r = 0; r < input.rows-1; r++)
-      for (int c = 0; c < input.cols-1; c++) 
+      for (int c = 0; c < input.cols-1; c++)
       {
-         const int r2 = r << 1; 
+         const int r2 = r << 1;
          const int c2 = c << 1;
          n.at<float>(r2,c2)     = in[0];
          n.at<float>(r2+1,c2)   = 0.5f *(in[0]+in[input.step]);
@@ -312,14 +312,14 @@ Mat doubleImage(const Mat &input)
       }
    for (int r = 0; r < input.rows-1; r++)
    {
-      const int r2 = r << 1; 
+      const int r2 = r << 1;
       const int c2 = (input.cols-1) << 1;
       n.at<float>(r2,c2)   = input.at<float>(r,input.cols-1);
       n.at<float>(r2+1,c2) = 0.5f*(input.at<float>(r,input.cols-1) + input.at<float>(r+1,input.cols-1));
    }
-   for (int c = 0; c < input.cols - 1; c++) 
+   for (int c = 0; c < input.cols - 1; c++)
    {
-      const int r2 = (input.rows-1) << 1; 
+      const int r2 = (input.rows-1) << 1;
       const int c2 = c << 1;
       n.at<float>(r2,c2)   = input.at<float>(input.rows-1,c);
       n.at<float>(r2,c2+1) = 0.5f*(input.at<float>(input.rows-1,c) + input.at<float>(input.rows-1,c+1));

--- a/pyramid.h
+++ b/pyramid.h
@@ -4,14 +4,14 @@
  *
  * This file is part of the HessianAffine detector and is made available under
  * the terms of the BSD license (see the COPYING file).
- * 
+ *
  */
 
 #ifndef __PYRAMID_H__
 #define __PYRAMID_H__
 
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/opencv.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 using namespace cv;
 
@@ -25,7 +25,7 @@ struct PyramidParams
    float initialSigma;
    // noise dependent threshold on the response (sensitivity)
    float threshold;
-   // ratio of the eigenvalues 
+   // ratio of the eigenvalues
    float edgeEigenValueRatio;
    // number of pixels ignored at the border of image
    int  border;
@@ -61,9 +61,9 @@ public:
       // thresholds are squared, response of det H is proportional to square of derivatives!
       finalThreshold(par.threshold * par.threshold),
       positiveThreshold(0.8 * finalThreshold),
-      negativeThreshold(-positiveThreshold) 
+      negativeThreshold(-positiveThreshold)
       {
-         this->par = par;  
+         this->par = par;
          hessianKeypointCallback = 0;
       }
    void setHessianKeypointCallback(HessianKeypointCallback *callback)
@@ -71,13 +71,13 @@ public:
          hessianKeypointCallback = callback;
       }
    void detectPyramidKeypoints(const Mat &image);
-   
-protected:   
+
+protected:
    void detectOctaveKeypoints(const Mat &firstLevel, float pixelDistance, Mat &nextOctaveFirstLevel);
    void localizeKeypoint(int r, int c, float curScale, float pixelDistance);
    void findLevelKeypoints(float curScale, float pixelDistance);
    Mat hessianResponse(const Mat &inputImage, float norm);
-   
+
 private:
    // some constants derived from parameters
    const float edgeScoreThreshold;

--- a/siftdesc.h
+++ b/siftdesc.h
@@ -4,7 +4,7 @@
  *
  * This file is part of the HessianAffine detector and is made available under
  * the terms of the BSD license (see the COPYING file).
- * 
+ *
  */
 
 // The SIFT descriptor is subject to US Patent 6,711,293
@@ -13,7 +13,7 @@
 #define __SIFTDESC_H__
 
 #include <vector>
-#include <cv.h>
+#include <opencv2/opencv.hpp>
 #include "helpers.h"
 
 struct SIFTDescriptorParams
@@ -28,7 +28,7 @@ struct SIFTDescriptorParams
          orientationBins = 8;
          maxBinValue = 0.2f;
          patchSize = 41;
-      } 
+      }
 };
 
 
@@ -39,7 +39,7 @@ public:
    // top level interface
    SIFTDescriptor(const SIFTDescriptorParams &par) :
       mask(par.patchSize, par.patchSize, CV_32FC1),
-      grad(par.patchSize, par.patchSize, CV_32FC1), 
+      grad(par.patchSize, par.patchSize, CV_32FC1),
       ori(par.patchSize, par.patchSize, CV_32FC1)
       {
          this->par = par;
@@ -47,7 +47,7 @@ public:
          computeCircularGaussMask(mask);
          precomputeBinsAndWeights();
       }
-   
+
    void computeSiftDescriptor(cv::Mat &patch);
 
 public:
@@ -55,7 +55,7 @@ public:
 
 private:
    // helper functions
-   
+
 float normalize();
    void sample();
    void samplePatch();


### PR DESCRIPTION
Changed `#include <cv.h>` to `#include <opencv2/opencv.hpp>` and `#include <highgui.h>` to `#include <opencv2/highgui/highgui.hpp>` to support compiling with the newest OpenCV2. (The other changes are removing spaces at the end of lines.)